### PR TITLE
Remove non-speech descriptions from output

### DIFF
--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -3,6 +3,7 @@ import argparse
 import httpx
 import logging
 import wave
+import re
 
 from io import BytesIO
 
@@ -66,6 +67,9 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         r = await client.post(self.cli_args.api, files=files, params=params, timeout=120.0)
                         #_LOGGER.debug(r.json())
                         text = r.json()['text']
+
+                text = re.sub(r'\[.*?\]', '', text).strip()
+                text = re.sub(r'\(.*?\)', '', text).strip()
 
             _LOGGER.info(text)
 


### PR DESCRIPTION
wyoming-whisper-cpp does something similar, but I've encountered far more non-speech tokens than just [BLANK AUDIO] so this change instead just removes square and round brackets and their contents altogether.
https://github.com/rhasspy/wyoming-whisper-cpp/blob/476b0e631392034a94196eb578b3d0a60164af53/wyoming_whisper_cpp/handler.py#L92