### PR TITLE
Update const.py to add yue language support

### DIFF
--- a/wyoming_whisper_api_client/const.py
+++ b/wyoming_whisper_api_client/const.py
@@ -97,5 +97,6 @@ WHISPER_LANGUAGES = [
     "vi",
     "yi",
     "yo",
+    "yue",
     "zh",
 ]


### PR DESCRIPTION
Added "yue" so that Home Assistant does not remove "yue" from Voice Assistant supported language list when wyoming-whisper-api-client is set as STT server