### PR TITLE
Add command line parameter to specify the model

### DIFF
--- a/wyoming_whisper_api_client/__main__.py
+++ b/wyoming_whisper_api_client/__main__.py
@@ -25,6 +25,11 @@ async def main() -> None:
         help="URL of whisper.cpp to use, http:// or https://",
     )
     parser.add_argument("--uri", required=True, help="unix:// or tcp://")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model name to use for transcription (sent as 'model' param to API)",
+    )
     parser.add_argument("--debug", action="store_true", help="Log DEBUG messages")
     parser.add_argument(
         "--log-format", default=logging.BASIC_FORMAT, help="Format for log messages"

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -63,6 +63,10 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                             "temperature_inc": "0.2",
                             "response_format": "json"
                         }
+
+                        if self.cli_args.model:
+                            params["model"] = self.cli_args.model
+
                         r = await client.post(self.cli_args.api, files=files, params=params, timeout=120.0)
                         #_LOGGER.debug(r.json())
                         text = r.json()['text']


### PR DESCRIPTION
## Summary

- Add `--model` CLI parameter to allow specifying which Whisper model to use when making the POST request to the API
- Intended for use with [llama-swap](https://github.com/mostlygeek/llama-swap) which requires a `model` parameter in the request to `/v1/audio/transcriptions`

## Changes

- `__main__.py`: Added `--model` argument with default `None`
- `handler.py`: Conditionally add `model` param to API request when provided

## Usage

```sh
./script/run --uri tcp://0.0.0.0:7891 --api http://llama-swap:8080/v1/audio/transcriptions 
      --model whisper-large-v3-turbo
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--model` command-line option to specify which transcription model to use when processing audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->