### PR TITLE
Docker Image publishing workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# VCS
+.github/
+.git/
+.gitignore
+LICENSE
+LICENSE.md
+MANIFEST.in
+README.md
+
+# Python cache/bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Build artifacts
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Tool caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Local editor/OS files
+.vscode/
+.idea/
+.DS_Store
+
+# Development-only content
+script/
+tests/
+.isort.cfg
+.projectile
+mypy.ini
+pylintrc
+requirements_dev.txt

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/wyoming-whisper-api-client
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,37 +6,43 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
+      - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/wyoming-whisper-api-client
+          images: ghcr.io/${{ github.repository_owner }}/wyoming-whisper-api-client
           tags: |
             type=raw,value=latest
+            type=sha
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git python3-pip bash \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends python3-pip bash \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/ser/wyoming-whisper-api-client
+COPY . /wyoming-whisper-api-client
 RUN pip3 install --no-cache-dir --break-system-packages -r wyoming-whisper-api-client/requirements.txt
 
 WORKDIR /wyoming-whisper-api-client/
-ADD run.sh ./
 RUN chmod +x run.sh
 
 ENTRYPOINT ["bash", "/wyoming-whisper-api-client/run.sh"]


### PR DESCRIPTION
Add automatic Docker image push to Docker Hub.

`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` must be added to the repository secrets.

Any push to the `main` branch triggers a workflow that builds and pushes a new `latest` image.

It can also be modified to run on new `v*` tags (e.g., `v1.0.0`), but I checked — there are currently no version tags in the repository :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image build & publish to GitHub Container Registry on main updates and manual runs; images include "latest" and commit-SHA tags, multi-arch support, caching, and concurrency safeguards.
  * Build now uses repository contents and includes the startup script set executable; reduced unnecessary system packages during image build.

* **New Files**
  * Added Docker ignore rules to shrink build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->