### PR TITLE
add docker instructions to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run a server anyone can connect to:
 
 ### Docker
 
-(**optional**, it already builded in GHCR image registry) Build the container:
+(**Optional**) The image is already published in GHCR. Build locally with:
 
 ```sh
 git clone https://github.com/ser/wyoming-whisper-api-client

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ whisper.cpp/server -m whisper.cpp/models/ggml-large-v3-q5_0.bin --host 0.0.0.0 -
 
 You need to study whisper.cpp to get more information about running its STT service.
 
-## Local Install
+## Installation
+
+### Local
 
 Clone the repository and set up Python virtual environment:
 
@@ -36,33 +38,33 @@ Run a server anyone can connect to:
 ./script/run --uri tcp://0.0.0.0:7891 --debug --api http://192.168.41.49:8910/inference
 ```
 
-## Docker Installation
+### Docker
 
-Clone the repository and build the docker image:
+(**optional**, it already builded in GHCR image registry) Build the container:
 
 ```sh
 git clone https://github.com/ser/wyoming-whisper-api-client
 cd wyoming-whisper-api-client
-docker build -t wyoming-whisper-api-client:latest .
+docker build -t ghcr.io/ser/wyoming-whisper-api-client:latest .
 ```
 
-Create the container:
+Run the container:
 
 ```sh
-docker container create -p 7891:7891 -i -t --name wyoming-whisper-api-client wyoming-whisper-api-client:latest --uri tcp://0.0.0.0:7891 --debug --api http://192.168.41.49:8910/inference
+docker run -p 7891:7891 -it --rm --name wyoming-whisper-api-client ghcr.io/ser/wyoming-whisper-api-client:latest \
+    --debug \
+    --uri tcp://0.0.0.0:7891 \
+    --api http://192.168.41.49:8910/inference
 ```
 
-Run The docker container:
+Attach for logging:
 
 ```sh
-# Detached in background
-docker start wyoming-whisper-api-client
-
-# Attached for debugging
-docker start wyoming-whisper-api-client --attach
+docker logs -f wyoming-whisper-api-client
 ```
 
 Stop the container:
+
 ```sh
 docker stop wyoming-whisper-api-client
 ```


### PR DESCRIPTION
Add Docker instructions to the README, as discussed in https://github.com/ser/wyoming-whisper-api-client/pull/11

Thought about Docker Compose, but it would also require a lot of documentation references to whisper.cpp, so I think that anyone who needs a Compose file can just write it themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized installation into "Installation → Local" and "Installation → Docker" subsections.
  * Simplified Docker setup to a single docker run flow using the published container image and included flags for debug, URI, and API.
  * Clarified logging instructions and added an "(Optional)" note for local image builds plus minor formatting fixes (blank line before stop snippet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->