### PR TITLE
whisper.cpp: forward transcribe request language

### DIFF
--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -59,6 +59,7 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         wavfile.setparams((1, 2, 16000, 0, 'NONE', 'NONE'))
                         wavfile.writeframes(self.audio)
 
+                        # A Transcribe event must always precede AudioStop, meaning the language should've been set by now.
                         assert self.language
 
                         files = {

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -60,12 +60,14 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         wavfile.setparams((1, 2, 16000, 0, 'NONE', 'NONE'))
                         wavfile.writeframes(self.audio)
 
-                        files: dict = {
-                            "file": tmpfile.getvalue(),
-                        }
+                        data = {}
 
                         if self.language:
-                            files["language"] = self.language
+                            data["language"] = self.language
+
+                        files = {
+                            "file": tmpfile.getvalue(),
+                        }
 
                         params = {
                             "temperature": "0.0",
@@ -76,7 +78,7 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         if self.cli_args.model:
                             params["model"] = self.cli_args.model
 
-                        r = await client.post(self.cli_args.api, files=files, params=params, timeout=120.0)
+                        r = await client.post(self.cli_args.api, files=files, data=data, params=params, timeout=120.0)
                         #_LOGGER.debug(r.json())
                         text = r.json()['text']
 

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -59,13 +59,13 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         wavfile.setparams((1, 2, 16000, 0, 'NONE', 'NONE'))
                         wavfile.writeframes(self.audio)
 
-                        # A Transcribe event must always precede AudioStop, meaning the language should've been set by now.
-                        assert self.language
-
-                        files = {
+                        files: dict = {
                             "file": tmpfile.getvalue(),
-                            "language": self.language,
                         }
+
+                        if self.language:
+                            files["language"] = self.language
+
                         params = {
                             "temperature": "0.0",
                             "temperature_inc": "0.2",

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -30,6 +30,7 @@ class WhisperAPIEventHandler(AsyncEventHandler):
         self.cli_args = cli_args
         self.wyoming_info_event = wyoming_info.event()
         self.audio = bytes()
+        self.language = None
         self.audio_converter = AudioChunkConverter(
             rate=16000,
             width=2,

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -66,7 +66,7 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                             data["language"] = self.language
 
                         files = {
-                            "file": tmpfile.getvalue(),
+                            "file": tmpfile.getvalue()
                         }
 
                         params = {

--- a/wyoming_whisper_api_client/handler.py
+++ b/wyoming_whisper_api_client/handler.py
@@ -37,6 +37,10 @@ class WhisperAPIEventHandler(AsyncEventHandler):
         )
 
     async def handle_event(self, event: Event) -> bool:
+        if Transcribe.is_type(event.type):
+            request = Transcribe.from_event(event)
+            self.language = request.language
+
         if AudioChunk.is_type(event.type):
             if not self.audio:
                 _LOGGER.debug("Receiving audio")
@@ -55,8 +59,11 @@ class WhisperAPIEventHandler(AsyncEventHandler):
                         wavfile.setparams((1, 2, 16000, 0, 'NONE', 'NONE'))
                         wavfile.writeframes(self.audio)
 
+                        assert self.language
+
                         files = {
-                            "file": tmpfile.getvalue()
+                            "file": tmpfile.getvalue(),
+                            "language": self.language,
                         }
                         params = {
                             "temperature": "0.0",
@@ -78,6 +85,7 @@ class WhisperAPIEventHandler(AsyncEventHandler):
 
             # Reset
             self.audio = bytes()
+            self.language = None
 
             return False
 


### PR DESCRIPTION
Fixes #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language handling in transcription requests by propagating the selected language through the audio pipeline and including it in the Whisper API request when available. Language state is now correctly cleared after each transcription session to prevent unintended reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->